### PR TITLE
Add extra IAM action from serverless docs

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,11 +9,13 @@
 const shouldSimplify = (s) => {
   /**
    * The resources for polices that define these permissions will be 'simplified'
+   * source: https://www.serverless.com/framework/docs/providers/aws/guide/iam
    */
   const LOG_ACTIONS_TO_SIMPLIFY = [
     "logs:CreateLogStream",
     "logs:CreateLogGroup",
     "logs:PutLogEvents",
+    "logs:TagResource",
   ];
 
   return (


### PR DESCRIPTION
Hey @danielreidwoebot !

I tried the original fork from shelfio but had no success and found yours which worked almost all the way.

There's a missed IAM action from https://www.serverless.com/framework/docs/providers/aws/guide/iam which gives 4 elements:
```
Action:
   - logs:CreateLogGroup
   - logs:CreateLogStream
   - logs:PutLogEvents
   - logs:TagResource
```